### PR TITLE
fixed buffer overflow at shader referencing

### DIFF
--- a/src/game/g_utils_mp.cpp
+++ b/src/game/g_utils_mp.cpp
@@ -708,7 +708,7 @@ int G_ShaderIndex( const char *name )
 {
 	char s[MAX_QPATH];
 
-	strcpy(s, name);
+	I_strncpyz(s, name, sizeof(s));
 	I_strlwr(s);
 
 	return G_FindConfigstringIndex( s, CS_SHADERS, MAX_SHADERS, level.initializing, "shader" );


### PR DESCRIPTION
Several script functions may allow untrusted user input cause a stack-based buffer overflow once the provided shader path is passed to an unsafe `strcpy`.